### PR TITLE
the .v10_16 alias is no more used by SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         .iOS(.v14),
-        .macOS(.v10_16),
+        .macOS(.v11),
         .tvOS(.v14)
     ],
     products: [


### PR DESCRIPTION
Fixes https://github.com/InvadingOctopus/octopuskit/issues/6
